### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # `docker.io/paketobuildpacks/aternity`
-The Paketo Aternity Buildpack is a Cloud Native Buildpack that contributes the [AppInternals][a] Agent and configures it to connect to the service.
+The Paketo Buildpack for Aternity is a Cloud Native Buildpack that contributes the [AppInternals][a] Agent and configures it to connect to the service.
 
 [a]: https://www.riverbed.com/products/steelcentral/steelcentral-appinternals.html
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/aternity"
   id = "paketo-buildpacks/aternity"
   keywords = ["riverbed", "aternity", "agent", "apm", "java"]
-  name = "Paketo Aternity Buildpack"
+  name = "Paketo Buildpack for Aternity"
   sbom-formats = ["application/vnd.syft+json", "application/vnd.cyclonedx+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Aternity Buildpack' to 'Paketo Buildpack for Aternity'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
